### PR TITLE
adds border-width and z-indices rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# Unreleased
+
+## Changed
+
+- `z-indices` rule
+- `border-width` rule
+
 # 1.1.1
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Like so:
 
 ## List of rules
 
+- [`border-width`](./lib/rules/border-width/README.md): Specify a scale for border-width.
 - [`color`](./lib/rules/color/README.md): Specify a scale for color.
 - [`font-family`](./lib/rules/font-family/README.md): Specify a scale for font-family.
 - [`font-size`](./lib/rules/font-size/README.md): Specify a scale for font-size.
@@ -38,6 +39,7 @@ Like so:
 - [`sizes`](./lib/rules/sizes/README.md): Specify a scale for sizes.
 - [`space`](./lib/rules/space/README.md): Specify a scale for space.
 - [`word-spacing`](./lib/rules/word-spacing/README.md): Specify a scale for word-spacing.
+- [`z-indices`](./lib/rules/z-indices/README.md): Specify a scale for z-indices.
 
 Ref: [Styled System Keys Reference](https://styled-system.com/theme-specification#key-reference)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 module.exports = [
+  require("./rules/border-width"),
   require("./rules/color"),
   require("./rules/font-family"),
   require("./rules/font-size"),
@@ -8,5 +9,6 @@ module.exports = [
   require("./rules/radii"),
   require("./rules/sizes"),
   require("./rules/space"),
-  require("./rules/word-spacing")
+  require("./rules/word-spacing"),
+  require("./rules/z-indices")
 ];

--- a/lib/rules/border-width/README.md
+++ b/lib/rules/border-width/README.md
@@ -1,0 +1,39 @@
+# border-width
+
+Specify a scale for border-width.
+
+```css
+a {
+  border-width: 0.1rem;
+}
+/**               ↑
+ *                This size */
+```
+
+This rule checks [font-relative](https://drafts.csswg.org/css-values-4/#font-relative-lengths) and [absolute](https://drafts.csswg.org/css-values-4/#absolute-lengths) lengths.
+
+## Options
+
+`array`
+
+Given:
+
+```json
+[0.1, 0.2]
+```
+
+The following patterns are considered violations:
+
+```css
+a {
+  border-width: 0.5rem;
+}
+```
+
+The following patterns are _not_ considered violations:
+
+```css
+a {
+  border-width: 0.1rem;
+}
+```

--- a/lib/rules/border-width/__tests__/index.js
+++ b/lib/rules/border-width/__tests__/index.js
@@ -1,0 +1,43 @@
+const rule = require("..");
+const { messages, ruleName } = rule;
+
+testRule(rule, {
+  ruleName,
+  config: [[1, 2]],
+
+  accept: [
+    {
+      code: "a { border-width: 1rem; }",
+      description: "Value on scale"
+    },
+    {
+      code: "a { border: 1rem solid grey; }",
+      description: "Value on scale"
+    },
+    {
+      code: "a { width: 3px; }",
+      description: "Ignored property"
+    },
+    {
+      code: "a { border-width: 3vh; }",
+      description: "Ignored unit"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a { border-width: 3rem }",
+      message: messages.expected("3", "1, 2"),
+      line: 1,
+      column: 19,
+      description: "Value off scale"
+    },
+    {
+      code: "a { border: 3rem solid grey; }",
+      message: messages.expected("3", "1, 2"),
+      line: 1,
+      column: 13,
+      description: "Value off scale"
+    }
+  ]
+});

--- a/lib/rules/border-width/index.js
+++ b/lib/rules/border-width/index.js
@@ -1,0 +1,67 @@
+const { isArray } = require("lodash");
+const { parse } = require("postcss-values-parser");
+const {
+  createPlugin,
+  utils: { report, ruleMessages, validateOptions }
+} = require("stylelint");
+
+const {
+  absoluteLengths,
+  fontRelativeLengths
+} = require("../../reference/valueSets");
+
+const parseShorthandBorder = require("../../utils/parseShorthandBorder");
+
+const lengthUnits = [...absoluteLengths, ...fontRelativeLengths];
+const ruleName = "scales/border-width";
+const messages = ruleMessages(ruleName, {
+  expected: (value, scale) => `Expected "${value}" to be one of "${scale}"`
+});
+
+const rule = scale => {
+  return (root, result) => {
+    // Validate the options
+    const validOptions = validateOptions(result, ruleName, {
+      actual: scale,
+      possible: isArray
+    });
+    if (!validOptions) return;
+    // Check border-width
+    root.walkDecls("border-width", decl => {
+      const { value } = decl;
+      check(decl, value);
+    });
+    // Check border-width
+    root.walkDecls("border", decl => {
+      const { value } = decl;
+      const { borderWidth } = parseShorthandBorder(value, result, decl);
+      check(decl, borderWidth);
+    });
+    // Check the size
+    function check(decl, size) {
+      // Parse the size and walk through Numerics
+      parse(size, {
+        ignoreUnknownWords: true
+      }).walkNumerics(({ value, unit }) => {
+        // Return early if not an checked unit
+        if (!lengthUnits.includes(unit)) return;
+        // Return early if the value is on the scale
+        if (scale.includes(Number(value))) return;
+        // Get message of the violation
+        const message = messages.expected(`${value}`, scale.join(", "));
+        // Report the violation to stylelint
+        report({
+          message,
+          node: decl,
+          result,
+          ruleName,
+          word: value
+        });
+      });
+    }
+  };
+};
+
+module.exports = createPlugin(ruleName, rule);
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/lib/rules/color/__tests__/index.js
+++ b/lib/rules/color/__tests__/index.js
@@ -21,6 +21,10 @@ testRule(rule, {
     {
       code: "a { color: rgba(0, 0, 0, 0.25); }",
       description: "RGBA on scale"
+    },
+    {
+      code: "a { border: 1px solid rgba(0, 0, 0, 0.25); }",
+      description: "RGBA on scale"
     }
   ],
 

--- a/lib/rules/z-indices/README.md
+++ b/lib/rules/z-indices/README.md
@@ -1,0 +1,37 @@
+# z-indices
+
+Specify a scale for z-indices.
+
+```css
+a {
+  z-index: 1;
+}
+/**        ↑
+ *         This z-order */
+```
+
+## Options
+
+`array`
+
+Given:
+
+```json
+[1, 2]
+```
+
+The following patterns are considered violations:
+
+```css
+a {
+  z-index: 35;
+}
+```
+
+The following patterns are _not_ considered violations:
+
+```css
+a {
+  z-index: 1;
+}
+```

--- a/lib/rules/z-indices/__tests__/index.js
+++ b/lib/rules/z-indices/__tests__/index.js
@@ -1,0 +1,46 @@
+const rule = require("..");
+const { messages, ruleName } = rule;
+
+testRule(rule, {
+  ruleName,
+  config: [[-1, 1, 2]],
+
+  accept: [
+    {
+      code: "a { z-index: 1 }",
+      description: "Value on scale"
+    },
+    {
+      code: "a { z-index: -1 }",
+      description: "Value on scale"
+    },
+    {
+      code: "a { border-width: 1px }",
+      description: "Ignored property"
+    }
+  ],
+
+  reject: [
+    {
+      code: "a { z-index: 3 }",
+      message: messages.expected("3", "-1, 1, 2"),
+      line: 1,
+      column: 14,
+      description: "Value off scale"
+    },
+    {
+      code: "a { z-index: -2 }",
+      message: messages.expected("-2", "-1, 1, 2"),
+      line: 1,
+      column: 14,
+      description: "Value off scale"
+    },
+    {
+      code: "a { z-index: 0 }",
+      message: messages.expected("0", "-1, 1, 2"),
+      line: 1,
+      column: 14,
+      description: "Value off scale"
+    }
+  ]
+});

--- a/lib/rules/z-indices/index.js
+++ b/lib/rules/z-indices/index.js
@@ -1,0 +1,50 @@
+const { isArray } = require("lodash");
+const { parse } = require("postcss-values-parser");
+const {
+  createPlugin,
+  utils: { report, ruleMessages, validateOptions }
+} = require("stylelint");
+
+const ruleName = "scales/z-indices";
+const messages = ruleMessages(ruleName, {
+  expected: (value, scale) => `Expected "${value}" to be one of "${scale}"`
+});
+
+// Properties to apply the scale to
+const propertyFilter = /z-index$/;
+
+const rule = scale => {
+  return (root, result) => {
+    // Validate the options
+    const validOptions = validateOptions(result, ruleName, {
+      actual: scale,
+      possible: isArray
+    });
+    if (!validOptions) return;
+    // Walk through all the (filtered) declarations in the source
+    root.walkDecls(propertyFilter, decl => {
+      const { value } = decl;
+      // Parse the decl value and walk through Numerics
+      parse(value, {
+        ignoreUnknownWords: true
+      }).walkNumerics(({ value }) => {
+        // Return early if the value is on the scale
+        if (scale.includes(Number(value))) return;
+        // Get  message of the violation
+        const message = messages.expected(`${value}`, scale.join(", "));
+        // Report the violation to stylelint
+        report({
+          message,
+          node: decl,
+          result,
+          ruleName,
+          word: value
+        });
+      });
+    });
+  };
+};
+
+module.exports = createPlugin(ruleName, rule);
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;

--- a/lib/utils/parseShorthandBorder.js
+++ b/lib/utils/parseShorthandBorder.js
@@ -1,4 +1,5 @@
 var border = require("css-border-property");
+const camelCase = require("camelcase");
 
 /**
  * Attempts to parse a border shorthand
@@ -9,19 +10,7 @@ var border = require("css-border-property");
 module.exports = function parseShorthandBorder(value, result, node) {
   try {
     const parsed = border.parse(value).reduce((memo, item) => {
-      switch (item.property) {
-        case "border-color":
-          memo.borderColor = item.value;
-          break;
-        case "border-style":
-          memo.borderStyle = item.value;
-          break;
-        case "border-width":
-          memo.borderWidth = item.value;
-          break;
-        default:
-          memo[item.property] = item.value;
-      }
+      memo[camelCase(item.property)] = item.value;
       return memo;
     }, {});
 

--- a/lib/utils/parseShorthandBorder.js
+++ b/lib/utils/parseShorthandBorder.js
@@ -1,0 +1,40 @@
+var border = require("css-border-property");
+
+/**
+ * Attempts to parse a border shorthand
+ * and attaches a warning to the stylelint result if it can't
+ *
+ * This is needed to stop editor extensions displaying errors
+ */
+module.exports = function parseShorthandBorder(value, result, node) {
+  try {
+    const parsed = border.parse(value).reduce((memo, item) => {
+      switch (item.property) {
+        case "border-color":
+          memo.borderColor = item.value;
+          break;
+        case "border-style":
+          memo.borderStyle = item.value;
+          break;
+        case "border-width":
+          memo.borderWidth = item.value;
+          break;
+        default:
+          memo[item.property] = item.value;
+      }
+      return memo;
+    }, {});
+
+    return parsed;
+  } catch (e) {
+    result.warn("Cannot parse border shorthand", {
+      node,
+      stylelintType: "parseError"
+    });
+    return {
+      borderColor: "",
+      borderWidth: "",
+      borderStyle: ""
+    };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "release": "np"
   },
   "dependencies": {
+    "css-border-property": "^1.1.0",
     "font-family": "^0.2.0",
     "lodash": "^4.17.15",
     "parse-css-font": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "release": "np"
   },
   "dependencies": {
+    "camelcase": "^5.3.1",
     "css-border-property": "^1.1.0",
     "font-family": "^0.2.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

Adds border-width and z-indices rules. Border-width uses an util function to parse shorthand border declarations. Installs 'css-border-property' package so `npm i`
