### PR TITLE
Fixes bug where shorthand border property declared as none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+## Changed
+
+- Border width rule no longer checks against `none` value.
+
 # 1.2.0
 
 ## Added

--- a/lib/rules/border-width/__tests__/index.js
+++ b/lib/rules/border-width/__tests__/index.js
@@ -24,7 +24,7 @@ testRule(rule, {
     },
     {
       code: "a { border: none; }",
-      description: "Accepts none as valid"
+      description: "none value ignored"
     }
   ],
 

--- a/lib/rules/border-width/__tests__/index.js
+++ b/lib/rules/border-width/__tests__/index.js
@@ -21,6 +21,10 @@ testRule(rule, {
     {
       code: "a { border-width: 3vh; }",
       description: "Ignored unit"
+    },
+    {
+      code: "a { border: none; }",
+      description: "Accepts none as valid"
     }
   ],
 

--- a/lib/rules/border-width/index.js
+++ b/lib/rules/border-width/index.js
@@ -46,7 +46,11 @@ const rule = (scale, options = {}) => {
     // Check border-width
     root.walkDecls("border", decl => {
       const { value } = decl;
+
+      if (value === "none") return;
+
       const { borderWidth } = parseShorthandBorder(value, result, decl);
+
       check(decl, borderWidth);
     });
     // Check the size

--- a/lib/rules/border-width/index.js
+++ b/lib/rules/border-width/index.js
@@ -50,7 +50,6 @@ const rule = (scale, options = {}) => {
       if (value === "none") return;
 
       const { borderWidth } = parseShorthandBorder(value, result, decl);
-
       check(decl, borderWidth);
     });
     // Check the size


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

Fixes #29 - setting border property to `none` passed an undefined border width to check function. 

> Is there anything in the PR that needs further explanation?

No