### PR TITLE
Add support for per-unit scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+## Added
+
+- support for per unit scales to `font-size` and `space`
+
 # 1.5.0
 
 ## Changed

--- a/lib/rules/font-size/README.md
+++ b/lib/rules/font-size/README.md
@@ -16,13 +16,12 @@ This rule checks [font-relative](https://drafts.csswg.org/css-values-4/#font-rel
 
 `array`
 
+Array of numbers or an array of objects as `{units: [], scale: []}`
+
 Given:
 
 ```json
-{
-  "scale": [1, 1.5],
-  "units": ["px", "rem"]
-}
+[1, 1.5]
 ```
 
 The following patterns are considered violations:
@@ -39,9 +38,40 @@ a {
 }
 ```
 
+The following patterns are _not_ considered violations:
+
 ```css
 a {
-  font-size: 1em;
+  font-size: 1rem;
+}
+```
+
+```css
+a {
+  font: 1.5px/1 serif;
+}
+```
+
+Given:
+
+```json
+[
+  { "units": ["em", "rem"], "scale": [1, 2] },
+  { "units": ["px"], "scale": [16, 32] }
+]
+```
+
+The following patterns are considered violations:
+
+```css
+a {
+  font-size: 16rem;
+}
+```
+
+```css
+a {
+  font: 2px/1 serif;
 }
 ```
 
@@ -55,7 +85,7 @@ a {
 
 ```css
 a {
-  font: 1.5px/1 serif;
+  font: 16px/1 serif;
 }
 ```
 

--- a/lib/rules/font-size/__tests__/index.js
+++ b/lib/rules/font-size/__tests__/index.js
@@ -41,3 +41,47 @@ testRule(rule, {
     },
   ],
 });
+
+testRule(rule, {
+  ruleName,
+  config: [
+    [
+      {
+        units: ["em", "rem"],
+        scale: [1, 2],
+      },
+      {
+        units: ["px"],
+        scale: [3, 4],
+      },
+    ],
+  ],
+
+  accept: [
+    {
+      code: "a { font-size: 3px; }",
+      description: "Value on scale",
+    },
+    {
+      code: "a { font: 400 1rem/1 serif; }",
+      description: "Value on scale in shorthand",
+    },
+  ],
+
+  reject: [
+    {
+      code: "a { font-size: 3em; }",
+      message: messages.expected("3em", "1, 2"),
+      line: 1,
+      column: 16,
+      description: "Value off scale",
+    },
+    {
+      code: "a { font: 700 1px/1 sans-serif; }",
+      message: messages.expected("1px", "3, 4"),
+      line: 1,
+      column: 15,
+      description: "Value off scale in shorthand",
+    },
+  ],
+});

--- a/lib/rules/font-size/index.js
+++ b/lib/rules/font-size/index.js
@@ -1,4 +1,4 @@
-const { isArray, isString } = require("lodash");
+const { isArray, isString, isObject } = require("lodash");
 const { parse } = require("postcss-values-parser");
 const {
   createPlugin,
@@ -16,14 +16,14 @@ const lengthUnits = [...absoluteLengths, ...fontRelativeLengths];
 const ruleName = "scales/font-size";
 const messages = generateStandardRuleMessage(ruleName);
 
-const rule = (scale, options = {}) => {
+const rule = (primary, options = {}) => {
   return (root, result) => {
     // Validate the options
     const validOptions = validateOptions(
       result,
       ruleName,
       {
-        actual: scale,
+        actual: primary,
         possible: isArray,
       },
       {
@@ -55,6 +55,17 @@ const rule = (scale, options = {}) => {
       }).walkNumerics(({ value, unit: valueUnit }) => {
         // Return early if not a checked unit
         if (!lengthUnits.includes(valueUnit)) return;
+
+        let scale = primary;
+
+        // Object based scale?
+        if (primary.some((e) => isObject(e))) {
+          const match = primary.find((objects) =>
+            objects.units.some((unit) => unit === valueUnit)
+          );
+          if (match == undefined) return;
+          scale = match.scale;
+        }
 
         // Validate scale and units
         const validUnit = unit ? valueUnit === unit : true;

--- a/lib/rules/space/README.md
+++ b/lib/rules/space/README.md
@@ -16,6 +16,8 @@ This rule checks [font-relative](https://drafts.csswg.org/css-values-4/#font-rel
 
 `array`
 
+Array of numbers or an array of objects as `{units: [], scale: []}`
+
 Given:
 
 ```json
@@ -41,6 +43,49 @@ The following patterns are _not_ considered violations:
 ```css
 a {
   margin: 16rem;
+}
+```
+
+```css
+a {
+  grid-gap: 32px;
+}
+```
+
+Given:
+
+```json
+[
+  { "units": ["em", "rem"], "scale": [1, 2] },
+  { "units": ["px"], "scale": [16, 32] }
+]
+```
+
+The following patterns are considered violations:
+
+```css
+a {
+  margin: 16rem;
+}
+```
+
+```css
+a {
+  margin: 2px;
+}
+```
+
+The following patterns are _not_ considered violations:
+
+```css
+a {
+  margin: 1em;
+}
+```
+
+```css
+a {
+  margin: 2rem;
 }
 ```
 

--- a/lib/rules/space/__tests__/index.js
+++ b/lib/rules/space/__tests__/index.js
@@ -68,3 +68,55 @@ testRule(rule, {
     },
   ],
 });
+
+testRule(rule, {
+  ruleName,
+  config: [
+    [
+      {
+        units: ["em", "rem"],
+        scale: [1, 2],
+      },
+      {
+        units: ["px"],
+        scale: [3, 4],
+      },
+    ],
+  ],
+
+  accept: [
+    {
+      code: "a { margin: 1rem; }",
+      description: "Value on scale",
+    },
+    {
+      code: "a { margin: 2em; }",
+      description: "Value on scale",
+    },
+    {
+      code: "a { margin: 3px; }",
+      description: "Value on scale",
+    },
+    {
+      code: "a { margin: 5ch; }",
+      description: "Value off scale but off unit",
+    },
+  ],
+
+  reject: [
+    {
+      code: "a { padding: 3rem }",
+      message: messages.expected("3rem", "1, 2"),
+      line: 1,
+      column: 14,
+      description: "Value off scale",
+    },
+    {
+      code: "a { padding: 1px }",
+      message: messages.expected("1px", "3, 4"),
+      line: 1,
+      column: 14,
+      description: "Value off scale",
+    },
+  ],
+});

--- a/lib/rules/space/index.js
+++ b/lib/rules/space/index.js
@@ -1,4 +1,4 @@
-const { isArray, isString } = require("lodash");
+const { isArray, isString, isObject } = require("lodash");
 const { parse } = require("postcss-values-parser");
 const {
   createPlugin,
@@ -25,14 +25,14 @@ const messages = generateStandardRuleMessage(ruleName);
 // Properties to apply the scale to
 const propertyFilter = /grid.*-gap|^margin|^padding/;
 
-const rule = (scale, options = {}) => {
+const rule = (primary, options = {}) => {
   return (root, result) => {
     // Validate the options
     const validOptions = validateOptions(
       result,
       ruleName,
       {
-        actual: scale,
+        actual: primary,
         possible: isArray,
       },
       {
@@ -59,6 +59,17 @@ const rule = (scale, options = {}) => {
       }).walkNumerics(({ value, unit: valueUnit }) => {
         // Return early if not a checked unit
         if (!lengthUnits.includes(valueUnit)) return;
+
+        let scale = primary;
+
+        // Object based scale?
+        if (primary.some((e) => isObject(e))) {
+          const match = primary.find((objects) =>
+            objects.units.some((unit) => unit === valueUnit)
+          );
+          if (match == undefined) return;
+          scale = match.scale;
+        }
 
         // Validate scale and units
         const validUnit = unit ? valueUnit === unit : true;


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will very likely be closed.

Each pull request should, with the exception of minor documentation fixes, be associated with an open issue. If there is an associated open issue, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/signal-noise/stylelint-scales/issues/45
Closes https://github.com/signal-noise/stylelint-scales/issues/46

> Is there anything in the PR that needs further explanation?

👋 I've been kindly granted contributor access to the repo, even though I'm no longer freelancing at Signal Noise. This pull request scratches the first of a few itches I have with this package; with the benefit of hindsight, there are a few things I'd design differently than how I did originally.

It adds support for per-unit scales to the `font-size` and `space` rules in a non-breaking way. 

I've gone with an array of objects for the primary option, rather than an object [as in my original proposal](https://github.com/signal-noise/stylelint-scales/issues/46#issuecomment-769014334), to:
- avoid [this incompatibility](https://stylelint.io/developer-guide/rules#add-options)
- support multiple units for each scale
- be compatible (I hope) with autofix

@jesusbotella Will the changes here work for [your use case](https://github.com/signal-noise/stylelint-scales/issues/46#issue-701780420)? You'll be able to define different scales for pixels and rems for your font sizes, e.g:

```json
{ 
  "rules": {
    "scales/font-size": [[
      {
        "units": ["rem"],
        "scale": [1, 2],
      },
      {
        "units": ["px"],
        "scale": [16],
      }
    ]]
  }
}
```





