### PR TITLE
Add support for array as the primary option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 
 - support for per unit scales to `font-size` and `space`
+- support for unenclosed array primary options
 
 # 1.5.0
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Like so:
   "plugins": ["@signal-noise/stylelint-scales"],
   "rules": {
     "scales/font-size": [[1, 1.5, 2], { unit: "rem" }],
-    "scales/font-weight": [[400, 600]],
+    "scales/font-weight": [400, 600],
     "scales/radii": [[4, 8, 16], { unit: "px" }]
   }
 }

--- a/lib/rules/border-width/__tests__/index.js
+++ b/lib/rules/border-width/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[1, 2]],
+  config: [1, 2],
 
   accept: [
     {

--- a/lib/rules/border-width/index.js
+++ b/lib/rules/border-width/index.js
@@ -90,6 +90,7 @@ const rule = (scale, options = {}) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/color/index.js
+++ b/lib/rules/color/index.js
@@ -90,6 +90,7 @@ const rule = (
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/font-family/__tests__/index.js
+++ b/lib/rules/font-family/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [["Times New Roman", "Times", "serif"]],
+  config: ["Times New Roman", "Times", "serif"],
 
   accept: [
     {

--- a/lib/rules/font-family/index.js
+++ b/lib/rules/font-family/index.js
@@ -61,6 +61,7 @@ const rule = (scale) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/font-size/__tests__/index.js
+++ b/lib/rules/font-size/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[1, 2]],
+  config: [1, 2],
 
   accept: [
     {
@@ -44,16 +44,14 @@ testRule({
 testRule({
   ruleName,
   config: [
-    [
-      {
-        units: ["em", "rem"],
-        scale: [1, 2],
-      },
-      {
-        units: ["px"],
-        scale: [3, 4],
-      },
-    ],
+    {
+      units: ["em", "rem"],
+      scale: [1, 2],
+    },
+    {
+      units: ["px"],
+      scale: [3, 4],
+    },
   ],
 
   accept: [

--- a/lib/rules/font-size/index.js
+++ b/lib/rules/font-size/index.js
@@ -98,6 +98,7 @@ const rule = (primary, options = {}) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/font-weight/__tests__/index.js
+++ b/lib/rules/font-weight/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[400, 700, "bold"]],
+  config: [400, 700, "bold"],
 
   accept: [
     {

--- a/lib/rules/font-weight/index.js
+++ b/lib/rules/font-weight/index.js
@@ -54,6 +54,7 @@ const rule = (scale) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/letter-spacing/__tests__/index.js
+++ b/lib/rules/letter-spacing/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[1, 2]],
+  config: [1, 2],
 
   accept: [
     {

--- a/lib/rules/letter-spacing/index.js
+++ b/lib/rules/letter-spacing/index.js
@@ -81,6 +81,7 @@ const rule = (scale, options = {}) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/line-height/__tests__/index.js
+++ b/lib/rules/line-height/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[1, 2]],
+  config: [1, 2],
 
   accept: [
     {

--- a/lib/rules/line-height/index.js
+++ b/lib/rules/line-height/index.js
@@ -51,6 +51,7 @@ const rule = (scale) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/radii/__tests__/index.js
+++ b/lib/rules/radii/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[1, 2]],
+  config: [1, 2],
 
   accept: [
     {

--- a/lib/rules/radii/index.js
+++ b/lib/rules/radii/index.js
@@ -80,6 +80,7 @@ const rule = (scale, options = {}) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/sizes/__tests__/index.js
+++ b/lib/rules/sizes/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[100, 200]],
+  config: [100, 200],
 
   accept: [
     {

--- a/lib/rules/sizes/index.js
+++ b/lib/rules/sizes/index.js
@@ -89,6 +89,7 @@ const rule = (scale, options = {}) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/space/__tests__/index.js
+++ b/lib/rules/space/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[1, 2]],
+  config: [1, 2],
 
   accept: [
     {
@@ -71,16 +71,14 @@ testRule({
 testRule({
   ruleName,
   config: [
-    [
-      {
-        units: ["em", "rem"],
-        scale: [1, 2],
-      },
-      {
-        units: ["px"],
-        scale: [3, 4],
-      },
-    ],
+    {
+      units: ["em", "rem"],
+      scale: [1, 2],
+    },
+    {
+      units: ["px"],
+      scale: [3, 4],
+    },
   ],
 
   accept: [

--- a/lib/rules/space/index.js
+++ b/lib/rules/space/index.js
@@ -102,6 +102,7 @@ const rule = (primary, options = {}) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/word-spacing/__tests__/index.js
+++ b/lib/rules/word-spacing/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[1, 2]],
+  config: [1, 2],
 
   accept: [
     {

--- a/lib/rules/word-spacing/index.js
+++ b/lib/rules/word-spacing/index.js
@@ -81,6 +81,7 @@ const rule = (scale, options = {}) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;

--- a/lib/rules/z-indices/__tests__/index.js
+++ b/lib/rules/z-indices/__tests__/index.js
@@ -2,7 +2,7 @@ const { messages, ruleName } = require("..");
 
 testRule({
   ruleName,
-  config: [[-1, 1, 2]],
+  config: [-1, 1, 2],
 
   accept: [
     {

--- a/lib/rules/z-indices/index.js
+++ b/lib/rules/z-indices/index.js
@@ -45,6 +45,7 @@ const rule = (scale) => {
   };
 };
 
+rule.primaryOptionArray = true;
 module.exports = createPlugin(ruleName, rule);
 module.exports.ruleName = ruleName;
 module.exports.messages = messages;


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will very likely be closed.

Each pull request should, with the exception of minor documentation fixes, be associated with an open issue. If there is an associated open issue, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Uses [this feature of stylelint](https://stylelint.io/developer-guide/plugins#allow-primary-option-arrays) to remove the need to enclose primary options in an array.

For example, this:

```js
{
  "rules": {
    "scales/font-weight": [[400, 600]],
  }
}
```

Can now be:

```js
{
  "rules": {
    "scales/font-weight": [400, 600],
  }
}
```
