### PR TITLE
Change to check logical properties and gap shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+## Changed
+
+- rules now check logical properties and shorthand gap
+
 ## Added
 
 - support for per unit scales to `font-size` and `space`

--- a/lib/rules/border-width/__tests__/index.js
+++ b/lib/rules/border-width/__tests__/index.js
@@ -36,6 +36,13 @@ testRule({
       description: "Value off scale",
     },
     {
+      code: "a { border-block-width: 3rem }",
+      message: messages.expected("3rem", "1, 2"),
+      line: 1,
+      column: 25,
+      description: "Value off scale",
+    },
+    {
       code: "a { border: 3rem solid grey; }",
       message: messages.expected("3rem", "1, 2"),
       line: 1,

--- a/lib/rules/border-width/index.js
+++ b/lib/rules/border-width/index.js
@@ -38,7 +38,7 @@ const rule = (scale, options = {}) => {
     if (!validOptions) return;
     const { unit } = options;
     // Check border-width
-    root.walkDecls("border-width", (decl) => {
+    root.walkDecls(/border.*width/, (decl) => {
       const { value } = decl;
       check(decl, value);
     });

--- a/lib/rules/radii/__tests__/index.js
+++ b/lib/rules/radii/__tests__/index.js
@@ -55,6 +55,13 @@ testRule({
       description: "Long hand value off scale",
     },
     {
+      code: "a { border-start-end-radius: 4px }",
+      message: messages.expected("4px", "1, 2"),
+      line: 1,
+      column: 30,
+      description: "Long hand value off scale",
+    },
+    {
       code: "a { border-bottom-left-radius: calc(100% - 3rem); }",
       message: messages.expected("3rem", "1, 2"),
       line: 1,

--- a/lib/rules/sizes/__tests__/index.js
+++ b/lib/rules/sizes/__tests__/index.js
@@ -46,5 +46,19 @@ testRule({
       column: 16,
       description: "Value off scale",
     },
+    {
+      code: "a { block-size: 120rem }",
+      message: messages.expected("120rem", "100, 200"),
+      line: 1,
+      column: 17,
+      description: "Value off scale",
+    },
+    {
+      code: "a { min-inline-size: 50rem }",
+      message: messages.expected("50rem", "100, 200"),
+      line: 1,
+      column: 22,
+      description: "Value off scale",
+    },
   ],
 });

--- a/lib/rules/sizes/index.js
+++ b/lib/rules/sizes/index.js
@@ -22,7 +22,7 @@ const ruleName = "scales/sizes";
 const messages = generateStandardRuleMessage(ruleName);
 
 // Properties to apply the scale to
-const propertyFilter = /^((min|max)-)?(height|width)/;
+const propertyFilter = /^((min|max)-)?(height|width|block|inline)/;
 
 const rule = (scale, options = {}) => {
   return (root, result) => {

--- a/lib/rules/space/__tests__/index.js
+++ b/lib/rules/space/__tests__/index.js
@@ -87,11 +87,11 @@ testRule({
       description: "Value on scale",
     },
     {
-      code: "a { margin: 2em; }",
+      code: "a { gap: 2em; }",
       description: "Value on scale",
     },
     {
-      code: "a { margin: 3px; }",
+      code: "a { margin-block-start: 3px; }",
       description: "Value on scale",
     },
     {
@@ -109,10 +109,31 @@ testRule({
       description: "Value off scale",
     },
     {
-      code: "a { padding: 1px }",
+      code: "a { gap: 1px }",
       message: messages.expected("1px", "3, 4"),
       line: 1,
+      column: 10,
+      description: "Value off scale",
+    },
+    {
+      code: "a { row-gap: 5px }",
+      message: messages.expected("5px", "3, 4"),
+      line: 1,
       column: 14,
+      description: "Value off scale",
+    },
+    {
+      code: "a { inset-block-end: 5px }",
+      message: messages.expected("5px", "3, 4"),
+      line: 1,
+      column: 22,
+      description: "Value off scale",
+    },
+    {
+      code: "a { margin-inline-start: 2px }",
+      message: messages.expected("2px", "3, 4"),
+      line: 1,
+      column: 26,
       description: "Value off scale",
     },
   ],

--- a/lib/rules/space/index.js
+++ b/lib/rules/space/index.js
@@ -23,7 +23,7 @@ const ruleName = "scales/space";
 const messages = generateStandardRuleMessage(ruleName);
 
 // Properties to apply the scale to
-const propertyFilter = /grid.*-gap|^margin|^padding/;
+const propertyFilter = /^inset|gap|^margin|^padding/;
 
 const rule = (primary, options = {}) => {
   return (root, result) => {


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will very likely be closed.

Each pull request should, with the exception of minor documentation fixes, be associated with an open issue. If there is an associated open issue, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

[List of logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).

I used to the [CSSTree reference tool](https://csstree.github.io/docs/syntax/) to check that the regexes won't catch unexpected properties.
