### PR TITLE
Fix options validator for missing arrays

### DIFF
--- a/lib/utils/__tests__/findScaleByUnit.js
+++ b/lib/utils/__tests__/findScaleByUnit.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const hasScalesWithUnits = require("../hasScalesWithUnits");
+
+it("rejects strings", () => {
+  expect(hasScalesWithUnits("string")).toBeFalsy();
+});
+
+it("rejects objects", () => {
+  expect(hasScalesWithUnits({})).toBeFalsy();
+});
+
+it("rejects empty arrays", () => {
+  expect(hasScalesWithUnits([])).toBeFalsy();
+});
+
+it("rejects empty objects", () => {
+  expect(hasScalesWithUnits([{}])).toBeFalsy();
+});
+
+it("rejects missing units property", () => {
+  expect(hasScalesWithUnits([{ scales: [0] }])).toBeFalsy();
+});
+
+it("rejects missing scales property", () => {
+  expect(hasScalesWithUnits([{ units: ["px"] }])).toBeFalsy();
+});
+
+it("rejects string instead of array", () => {
+  expect(hasScalesWithUnits([{ units: "px", scale: [0] }])).toBeFalsy();
+});
+
+it("rejects non-numeric scale values", () => {
+  expect(hasScalesWithUnits([{ units: ["px"], scale: ["0"] }])).toBeFalsy();
+});
+
+it("rejects non-string unit values", () => {
+  expect(hasScalesWithUnits([{ units: [0], scale: [0] }])).toBeFalsy();
+});
+
+it("accepts single value arrays", () => {
+  expect(hasScalesWithUnits([{ units: ["px"], scale: [0] }])).toBeTruthy();
+});
+
+it("accepts multiple value arrays", () => {
+  expect(
+    hasScalesWithUnits([{ units: ["px", "em"], scale: [0, 10] }])
+  ).toBeTruthy();
+});

--- a/lib/utils/hasScalesWithUnits.js
+++ b/lib/utils/hasScalesWithUnits.js
@@ -5,12 +5,20 @@
  * @return bool
  */
 module.exports = function hasScalesWithUnits(primary) {
-  return primary.every(
-    (obj) =>
-      typeof obj === "object" &&
-      "scale" in obj &&
-      "units" in obj &&
-      obj.scale.length > 0 &&
-      obj.units.length > 0
+  return (
+    Array.isArray(primary) &&
+    primary.length > 0 &&
+    primary.every(
+      (obj) =>
+        typeof obj === "object" &&
+        "scale" in obj &&
+        "units" in obj &&
+        Array.isArray(obj.scale) &&
+        obj.scale.length > 0 &&
+        obj.scale.every((value) => Number.isFinite(value)) &&
+        Array.isArray(obj.units) &&
+        obj.units.length > 0 &&
+        obj.units.every((value) => typeof value === "string")
+    )
   );
 };


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will very likely be closed.

Each pull request should, with the exception of minor documentation fixes, be associated with an open issue. If there is an associated open issue, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Fixes a `TypeError` throw for malformed configs where the `scale` and `units` values are strings and not arrays, e.g.:

```json
{
  "plugins": ["@signal-noise/stylelint-scales"],
  "rules": {
    "scales/letter-spacing": [{ "units": "px", "scale": 2 }],
  }
}
```
