### PR TITLE
Fix non-unit option validation

### DIFF
--- a/lib/rules/alpha-values/index.js
+++ b/lib/rules/alpha-values/index.js
@@ -7,6 +7,7 @@ const {
 const createRuleMessages = require("../../utils/createRuleMessages");
 const getClosest = require("../../utils/getClosest");
 const getValue = require("../../utils/getValue");
+const hasNumericScale = require("../../utils/hasNumericScale");
 const isOnNumericScale = require("../../utils/isOnNumericScale");
 const setValue = require("../../utils/setValue");
 
@@ -21,7 +22,7 @@ const rule = (primary, secondary, { fix }) => {
     if (
       !validateOptions(result, ruleName, {
         actual: primary,
-        possible: Array.isArray,
+        possible: hasNumericScale,
       })
     )
       return;

--- a/lib/rules/font-families/index.js
+++ b/lib/rules/font-families/index.js
@@ -1,4 +1,3 @@
-const { isArray } = require("lodash");
 const cssGlobalKeywords = require("css-global-keywords");
 
 const {
@@ -8,6 +7,7 @@ const {
 const { parse: parseFontFamily } = require("font-family");
 
 const createRuleMessages = require("../../utils/createRuleMessages");
+const hasStringScale = require("../../utils/hasStringScale");
 const parseShorthandFont = require("../../utils/parseShorthandFont");
 
 const ruleName = "scales/font-families";
@@ -19,7 +19,7 @@ const rule = (scale) => {
     // Validate the options
     const validOptions = validateOptions(result, ruleName, {
       actual: scale,
-      possible: isArray,
+      possible: hasStringScale,
     });
     if (!validOptions) return;
     // Walk through both font-family and font declarations in the source

--- a/lib/rules/font-weights/index.js
+++ b/lib/rules/font-weights/index.js
@@ -7,6 +7,7 @@ const {
 const createRuleMessages = require("../../utils/createRuleMessages");
 const getClosest = require("../../utils/getClosest");
 const getValue = require("../../utils/getValue");
+const hasNumericScale = require("../../utils/hasNumericScale");
 const isLineHeight = require("../../utils/isLineHeight");
 const isOnNumericScale = require("../../utils/isOnNumericScale");
 const setValue = require("../../utils/setValue");
@@ -21,7 +22,7 @@ const rule = (primary, secondary, { fix }) => {
     if (
       !validateOptions(result, ruleName, {
         actual: primary,
-        possible: Array.isArray,
+        possible: hasNumericScale,
       })
     )
       return;

--- a/lib/rules/line-heights/index.js
+++ b/lib/rules/line-heights/index.js
@@ -7,6 +7,7 @@ const {
 const createRuleMessages = require("../../utils/createRuleMessages");
 const getClosest = require("../../utils/getClosest");
 const getValue = require("../../utils/getValue");
+const hasNumericScale = require("../../utils/hasNumericScale");
 const isOnNumericScale = require("../../utils/isOnNumericScale");
 const setValue = require("../../utils/setValue");
 
@@ -20,7 +21,7 @@ const rule = (primary, secondary, { fix }) => {
     if (
       !validateOptions(result, ruleName, {
         actual: primary,
-        possible: Array.isArray,
+        possible: hasNumericScale,
       })
     )
       return;

--- a/lib/rules/z-indices/index.js
+++ b/lib/rules/z-indices/index.js
@@ -7,6 +7,7 @@ const {
 const createRuleMessages = require("../../utils/createRuleMessages");
 const getClosest = require("../../utils/getClosest");
 const getValue = require("../../utils/getValue");
+const hasNumericScale = require("../../utils/hasNumericScale");
 const isOnNumericScale = require("../../utils/isOnNumericScale");
 const setValue = require("../../utils/setValue");
 
@@ -20,7 +21,7 @@ const rule = (primary, secondary, { fix }) => {
     if (
       !validateOptions(result, ruleName, {
         actual: primary,
-        possible: Array.isArray,
+        possible: hasNumericScale,
       })
     )
       return;

--- a/lib/utils/__tests__/hasNumericScale.js
+++ b/lib/utils/__tests__/hasNumericScale.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const hasNumericScale = require("../hasNumericScale");
+
+it("rejects strings", () => {
+  expect(hasNumericScale("1")).toBeFalsy();
+});
+
+it("rejects objects", () => {
+  expect(hasNumericScale({})).toBeFalsy();
+});
+
+it("rejects empty arrays", () => {
+  expect(hasNumericScale([])).toBeFalsy();
+});
+
+it("rejects string values in arrays", () => {
+  expect(hasNumericScale(["0"])).toBeFalsy();
+});
+
+it("accepts single value arrays", () => {
+  expect(hasNumericScale([0])).toBeTruthy();
+});
+
+it("accepts multiple value arrays", () => {
+  expect(hasNumericScale([0, 1])).toBeTruthy();
+});

--- a/lib/utils/__tests__/hasStringScale.js
+++ b/lib/utils/__tests__/hasStringScale.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const hasStringScale = require("../hasStringScale");
+
+it("rejects numbers", () => {
+  expect(hasStringScale(1)).toBeFalsy();
+});
+
+it("rejects objects", () => {
+  expect(hasStringScale({})).toBeFalsy();
+});
+
+it("rejects empty arrays", () => {
+  expect(hasStringScale([])).toBeFalsy();
+});
+
+it("rejects numbers values in arrays", () => {
+  expect(hasStringScale([0])).toBeFalsy();
+});
+
+it("accepts single value arrays", () => {
+  expect(hasStringScale(["a"])).toBeTruthy();
+});
+
+it("accepts multiple value arrays", () => {
+  expect(hasStringScale(["a", "b"])).toBeTruthy();
+});

--- a/lib/utils/hasNumericScale.js
+++ b/lib/utils/hasNumericScale.js
@@ -1,0 +1,13 @@
+/**
+ * Check if primary option is a numeric scale
+ *
+ * @param primary array
+ * @return bool
+ */
+module.exports = function hasNumericScale(primary) {
+  return (
+    Array.isArray(primary) &&
+    primary.length > 0 &&
+    primary.every((value) => Number.isFinite(value))
+  );
+};

--- a/lib/utils/hasStringScale.js
+++ b/lib/utils/hasStringScale.js
@@ -1,0 +1,13 @@
+/**
+ * Check if primary option is a string scale
+ *
+ * @param primary array
+ * @return bool
+ */
+module.exports = function hasStringScale(primary) {
+  return (
+    Array.isArray(primary) &&
+    primary.length > 0 &&
+    primary.every((value) => typeof value === "string")
+  );
+};


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will very likely be closed.

Each pull request should, with the exception of minor documentation fixes, be associated with an open issue. If there is an associated open issue, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Fixes the validation of non-unit rules. For example, it'll catch:

```json
{
  "rules": {
    "scales/font-weight": [400, 600, "bold"]
  }
}
```

The pull request just includes the validation functions at the moment. I'll wire them into the applicable rules once all the other pull requests are reviewed and merged.

Option validation functions are difficult to test inside of the [`testRule` schema](https://github.com/stylelint/jest-preset-stylelint), hence the dedicated tests.