### PR TITLE
Add migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,64 +1,330 @@
 # Changelog
 
-# Unreleased
+## Unreleased
 
-## Removed
+### Migrating from 1.5.0
+
+The plugin pack can now automatically fix all numeric scales!
+
+A number of breaking changes were needed to make this possible.
+
+#### Rule names
+
+A handful of rules were renamed to consistently use plurals:
+
+- `border-width` to `border-widths`
+- `font-family` to `font-families`
+- `font-size` to `font-sizes`
+- `font-weight` to `font-weights`
+- `letter-spacing` to `letter-spacings`
+- `line-height` to `line-heights`
+- `word-spacing` to `word-spacings`
+
+For example, you should change the following:
+
+```json
+{
+  "rules": {
+    "scales/font-weight": [400, 600]
+  }
+}
+```
+
+To:
+
+```json
+{
+  "rules": {
+    "scales/font-weights": [400, 600]
+  }
+}
+```
+
+#### Option signatures
+
+Rules that check values with units now expect an array of objects for their primary option. Each object must specify two arrays:
+
+- `scale` - a numerical scale of allowed values
+- `units` - a list of units to apply the scale to
+
+This replaces the `unit` secondary option found on many of the rules.
+
+For example, you should change the following:
+
+```json
+{
+  "rules": {
+    "scales/font-size": [[1, 2], { "unit": "rem" }]
+  }
+}
+```
+
+To:
+
+```json
+{
+  "rules": {
+    "scales/font-sizes": [
+      {
+        "scale": [1, 2],
+        "units": ["rem"]
+      }
+    ]
+  }
+}
+```
+
+This will allow:
+
+```css
+a {
+  font-size: 1rem;
+}
+```
+
+You can now specify multiple units per scale, for example:
+
+```json
+{
+  "rules": {
+    "scales/font-sizes": [
+      {
+        "scale": [1, 2],
+        "units": ["em", "rem"]
+      }
+    ]
+  }
+}
+```
+
+This will allow:
+
+```css
+a {
+  font-size: 1em;
+}
+
+a {
+  font-size: 1rem;
+}
+```
+
+And multiple scales per rule, for example:
+
+```json
+{
+  "rules": {
+    "scales/font-sizes": [
+      {
+        "scale": [1, 2],
+        "units": ["rem"]
+      },
+      {
+        "scale": [12, 14],
+        "units": ["px"]
+      }
+    ]
+  }
+}
+```
+
+This will allow:
+
+```css
+a {
+  font-size: 1rem;
+}
+
+a {
+  font-size: 12px;
+}
+```
+
+#### Enforcing specific units
+
+The plugin pack no longer enforces the specified units. This is particularly useful when working with percentages and viewport units, which may not sit on a scale. You should use the [declaration-property-unit-allowed-list rule](https://stylelint.io/user-guide/rules/declaration-property-unit-allowed-list) in stylelint if you wish to enforce specific units.
+
+For example, you should change the following:
+
+```json
+{
+  "rules": {
+    "scales/font-size": [[1, 2], { "unit": "rem" }]
+  }
+}
+```
+
+To:
+
+```json
+{
+  "rules": {
+    "declaration-property-unit-allowed-list": {
+      "/^font$|^font-size$/": ["rem"]
+    },
+    "scales/font-sizes": [
+      {
+        "scale": [1, 2],
+        "units": ["rem"]
+      }
+    ]
+  }
+}
+```
+
+Appropriate regular expressions for the [declaration-property-unit-allowed-list rule](https://stylelint.io/user-guide/rules/declaration-property-unit-allowed-list) are documented in each of the rule READMEs.
+
+#### Only numeric values
+
+The rules now, with the exception of `font-families`, only accept numeric values. Non-numeric values in your CSS are now ignored.
+
+For example, you should change the following:
+
+```json
+{
+  "rules": {
+    "scales/font-weight": [400, 600, "bold"]
+  }
+}
+```
+
+To:
+
+```json
+{
+  "rules": {
+    "scales/font-weights": [400, 600]
+  }
+}
+```
+
+Numeric font weights are appropriate for both non-variable fonts, e.g. 100, 200, 300 and so on, and [variable fonts](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide), which range from 1 to 1000.
+
+#### Logical and gap properties
+
+The rules now check [logical properties](https://drafts.csswg.org/css-logical-1/) and [gap properties](https://drafts.csswg.org/css-align-3/#gaps), so more violations may be caught (and automatically fixed).
+
+#### Top-level arrays
+
+You no longer need to enclose top-level scale arrays in an array.
+
+For example, you should change the following:
+
+```json
+{
+  "rules": {
+    "scales/font-weight": [[400, 600]]
+  }
+}
+```
+
+To:
+
+```json
+{
+  "rules": {
+    "scales/font-weights": [400, 600]
+  }
+}
+```
+
+#### The `color` rule
+
+The `color` rule was removed. You should use CSS Variables for colours because, unlike numeric values and font family names, hex values and colour function notation are not human-readable. You can enforce a scale for alpha values using the new `alpha-values` rule.
+
+For example, you should change the following:
+
+```json
+{
+  "rules": {
+    "scales/color": [
+      [
+        [0, 0, 0],
+        [255, 255, 255]
+      ],
+      {
+        "alphaScale": [[0.5, 0.75]]
+      }
+    ]
+  }
+}
+```
+
+To:
+
+```json
+{
+  "rules": {
+    "scales/alpha-values": [50, 75]
+  }
+}
+```
+
+And write your CSS using CSS Variables for colour, for example:
+
+```css
+a {
+  color: hsl(var(--accent) / 50%);
+}
+```
+
+### Removed
 
 - `color` rule
 
-## Changed
+### Changed
 
 - names to be consistently pluralised
 - options signature for rules that check values with units
 - rules now check logical properties and shorthand gap
 
-## Added
+### Added
 
 - `alpha-values` rule
 - autofix to rules that check numeric scales
 - per unit scales for rules that check values with units
 - support for unenclosed array primary options
 
-# 1.5.0
+## 1.5.0
 
-## Removed
+### Removed
 
 - support for Node 8
 
-# 1.4.0
+## 1.4.0
 
-## Added
+### Added
 
 - unit display in messages for all relevant rules
 
-# 1.3.0
+## 1.3.0
 
-## Added
+### Added
 
 - support non-numerical font-weights
 
-## Fixed
+### Fixed
 
 - false positives for CSS global keywords in font shorthand declarations
 - `border-width` false positives for `none` value
 
-# 1.2.0
+## 1.2.0
 
-## Added
+### Added
 
 - `z-indices` rule
 - `border-width` rule
 - `unit` option on unit dependent scales
 
-# 1.1.1
+## 1.1.1
 
-## Fixed
+### Fixed
 
 - missing `sizes` documentation link
 
-# 1.1.0
+## 1.1.0
 
-## Added
+### Added
 
 - `sizes` rule
 - `font-family` rule
@@ -66,28 +332,28 @@
 - `radii` rule
 - `word-spacing` rule
 
-# 1.0.0
+## 1.0.0
 
-## Removed
+### Removed
 
 - `unit` secondary options from `scales/font-size` and `scales/space`
 
-## Changed
+### Changed
 
 - `scales/font-size` and `scales/space` now check all font-relative and absolute length values
 - `scales/space` now checks the `margin`, `padding` and `grip-gap` longhand and shorthand properties, and no longer checks the `box-shadow` and `border` ones
 
-## Fixed
+### Fixed
 
 - rationale in `README.md`
 - plugin name in example in `README.md`
 
-# 0.1.1
+## 0.1.1
 
-## Fixed
+### Fixed
 
 - documentation links in `package.json`
 
-# 0.1.0
+## 0.1.0
 
 - initial release


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will very likely be closed.

Each pull request should, with the exception of minor documentation fixes, be associated with an open issue. If there is an associated open issue, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

`2.0.0` will add autofixing to nearly all of the rules. This great for either retroactively adding scales to an existing codebase or authoring new CSS.

A number of breaking changes were needed to make this possible. This pull request adds a [migration guide](https://github.com/signal-noise/stylelint-scales/blob/cd640566c864829b32547a3ab4492ab0899c2b04/CHANGELOG.md) to help users update.

At-mentioning @sallynorthmore, @jesusbotella and @sixhours as you all recently raised bug reports and requested features in this package.

@sixhours I took a look at the public [Calypso stylelint config](https://github.com/Automattic/wp-calypso/blob/trunk/.stylelintrc). To update to 2.0.0, you can change the scales part of your configuration object to:

```json
{
  "plugins": ["@signal-noise/stylelint-scales"],
  "rules": {
    "declaration-property-unit-allowed-list": {
      "/^font-size$|^font$/": ["rem"],
      "/radius$/": ["px"]
    },
    "scales/font-weights": [400, 600, 700],
    "scales/font-sizes": [
      {
        "scale": [0.75, 0.875, 1, 1.25, 1.5, 2, 2.25, 3, 3.375],
        "units": ["rem"]
      }
    ],
    "scales/radii": [
      {
        "scale": [2],
        "units": ["px"]
      }
    ]
  }
}
```

Feel free to at-mention me in any issues or pull requests related to this package in the Calypso repo, and I'll do my best to help.

@sallynorthmore & @jesusbotella I don't believe your configs are public. You're welcome to ask questions in this thread if you run into issues updating to `2.0.0`.

I will release `2.0.0` shortly.

