### PR TITLE
Fix parse error for custom properties in font-families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- parse error for custom properties in `font-families`
+
 ## 2.0.0
 
 ### Migrating from 1.5.0

--- a/lib/rules/font-families/__tests__/index.js
+++ b/lib/rules/font-families/__tests__/index.js
@@ -18,6 +18,10 @@ testRule({
       description: "Allows initial value",
     },
     {
+      code: "a { font-family: var(--foo); }",
+      description: "Allows custom property",
+    },
+    {
       code: "a { font-family: Times, serif; }",
       description: "Multiple values on scale",
     },
@@ -28,6 +32,10 @@ testRule({
     {
       code: "a { font: 400 1rem/1 serif; }",
       description: "Value on scale in shorthand",
+    },
+    {
+      code: "a { font: 1rem var(--foo); }",
+      description: "Allows custom property in shorthand",
     },
     {
       code: "a { font: 400 1rem/1 Times, serif; }",

--- a/lib/rules/font-families/index.js
+++ b/lib/rules/font-families/index.js
@@ -26,16 +26,17 @@ const rule = (scale) => {
     // And extract the family from the shorthand
     // Then check each font-family found
     root.walkDecls("font-family", (decl) => {
+      if (decl.value.includes("var(")) return;
       const values = parseFontFamily(decl.value);
       values.forEach((value) => check(decl, value));
     });
     root.walkDecls("font", (decl) => {
       const { value } = decl;
+      if (value.includes("var(")) return;
       if (cssGlobalKeywords.includes(value)) {
         check(decl, value);
       } else {
         const { family } = parseShorthandFont(value, result, decl);
-
         family.forEach((value) => check(decl, value));
       }
     });


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will very likely be closed.

Each pull request should, with the exception of minor documentation fixes, be associated with an open issue. If there is an associated open issue, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

Fixes parse error in `font-families` rule when custom properties are used.

At some point, we should rewrite the rule to avoid the use of fragile parsers.
