### PR TITLE
Fix TypeError for system keyword in font-families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- type error for system keywords in `font-families`
+
 ## 2.0.1
 
 ### Fixed

--- a/lib/rules/font-families/README.md
+++ b/lib/rules/font-families/README.md
@@ -10,7 +10,7 @@ a {
  *             This font-family */
 ```
 
-This rule validates all found fonts declared, and allows css global keywords (`inherit`, `initial`, `unset`) as values.
+This rule validates all found fonts declared, and allows css global keywords (`inherit`, `initial`, `unset`) and system keywords (`caption`, `menu` etc) as values.
 
 ## Options
 

--- a/lib/rules/font-families/__tests__/index.js
+++ b/lib/rules/font-families/__tests__/index.js
@@ -38,6 +38,10 @@ testRule({
       description: "Allows custom property in shorthand",
     },
     {
+      code: "a { font: caption; }",
+      description: "Allows system keyword",
+    },
+    {
       code: "a { font: 400 1rem/1 Times, serif; }",
       description: "Multiple values on scale in shorthand",
     },

--- a/lib/rules/font-families/index.js
+++ b/lib/rules/font-families/index.js
@@ -37,6 +37,7 @@ const rule = (scale) => {
         check(decl, value);
       } else {
         const { family } = parseShorthandFont(value, result, decl);
+        if (!Array.isArray(family)) return;
         family.forEach((value) => check(decl, value));
       }
     });


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will very likely be closed.

Each pull request should, with the exception of minor documentation fixes, be associated with an open issue. If there is an associated open issue, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

None

> Is there anything in the PR that needs further explanation?

When looking into https://github.com/signal-noise/stylelint-scales/issues/69, I found that the rule produces a TypeError for system keywords like `caption`. The parser can parse these values but places them into a special `system` property, rather than a `family` one.

[Syntax for reference](https://developer.mozilla.org/en-US/docs/Web/CSS/font#syntax).
